### PR TITLE
fix: solved gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.19-alpine AS build
 
 RUN apk add --no-cache git
+RUN apk add gcc build-base
 
 RUN mkdir -p /go/src/ChatGPT-API-server
 WORKDIR /go/src/ChatGPT-API-server


### PR DESCRIPTION
Add to dockerfile the installation of gcc and build-base to solve this 2 errors:

## No gcc:
```
 => ERROR [build 3/7] RUN apt-get install gcc                                                                                                                         0.8s 
------
 > [build 3/7] RUN apt-get install gcc:
#0 0.525 /bin/sh: apt-get: not found
------
failed to solve: executor failed running [/bin/sh -c apt-get install gcc]: exit code: 127
```
## No build-base:
```
#0 9.741 /go/pkg/mod/github.com/mattn/go-sqlite3@v1.14.16/backup.go:14:10: fatal error: stdlib.h: No such file or directory
#0 9.741    14 | #include <stdlib.h>
#0 9.741       |          ^~~~~~~~~~
#0 9.741 compilation terminated.
```