### PR TITLE
main:add error printing when failed to create database

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	// Make database
 	err := utils.DatabaseCreate()
 	if err != nil {
-		println("Failed to create database")
+		println("Failed to create database:", err.Error())
 		return
 	}
 


### PR DESCRIPTION
If error occurs while creating database file or connect sqlite, we only have "Failed to create database" log, which we can't get any useful info about the error.
We need to add error printing when failed to create database.